### PR TITLE
Toggle showing on rendering depending on chrome extension initialization

### DIFF
--- a/lib/elements/Panel.js
+++ b/lib/elements/Panel.js
@@ -11,7 +11,7 @@ import key from 'keymaster';
 class Panel extends Component {
   constructor(props) {
     super(props);
-    this.state = {show: false};
+    this.state = {show: props.show};
     this.plugins = props.data.sections[data.sections.length - 1].name === 'Plugins'
       ? props.data.sections.pop()
       : [];
@@ -45,7 +45,7 @@ class Panel extends Component {
     // prepare plugin data
     let pluginsLeft = null;
     let pluginsRight = null;
-    if (this.plugins.shortcuts.length > 0) {
+    if (this.plugins.shortcuts && this.plugins.shortcuts.length > 0) {
       let pluginsLeftData = {name: this.plugins.name, shortcuts: this.plugins.shortcuts.slice(0, Math.ceil(this.plugins.shortcuts.length/2))};
       let pluginsRightData = {name: '', shortcuts: this.plugins.shortcuts.slice(Math.ceil(this.plugins.shortcuts.length/2), this.plugins.shortcuts.length)};
       pluginsLeft = pluginsLeftData.shortcuts.length > 0 ? <Section data={pluginsLeftData} key={key++}/> : null;
@@ -86,7 +86,8 @@ class Panel extends Component {
   }
 }
 Panel.propTypes = {
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  show: PropTypes.bool.isRequired
 }
 
 let styles = {


### PR DESCRIPTION
- This is so clicking on the macro icon shows the panel
- Also allow websites with shortcuts without plugins to be shown again